### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,3 +1,5 @@
+// Package client provides the etu journal backend client: configuration,
+// caching, and gRPC calls used by the CLI and TUI.
 package client
 
 import (
@@ -5,6 +7,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"log"
+	"math"
 	"mime"
 	"net"
 	"net/http"
@@ -28,7 +31,7 @@ type Post struct {
 
 // Config holds the configuration for the client.
 type Config struct {
-	ApiKey     string
+	APIKey     string
 	GRPCTarget string
 	grpc       *grpcClients
 }
@@ -50,14 +53,14 @@ func LoadConfig() *Config {
 	}
 	// Trim whitespace so pasted keys or env vars with trailing newlines don't break validation.
 	return &Config{
-		ApiKey:     strings.TrimSpace(cf.APIKey),
+		APIKey:     strings.TrimSpace(cf.APIKey),
 		GRPCTarget: strings.TrimSpace(cf.GRPCTarget),
 	}
 }
 
 // Validate checks that the API key is present.
 func (c *Config) Validate() error {
-	if c.ApiKey == "" {
+	if c.APIKey == "" {
 		return fmt.Errorf("API key required: set ETU_API_KEY or add api_key to config file")
 	}
 	c.warnIfTargetUnresolvable()
@@ -137,7 +140,8 @@ func (c *Config) cacheToFile(dur time.Duration) (err error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
-	f, err := os.Create(path)
+	// path is built from CachePath() (fixed config dir under user home), not external input.
+	f, err := os.Create(path) //nolint:gosec // G304: path is from fixed config dir, not user-controlled
 	if err != nil {
 		return err
 	}
@@ -154,7 +158,8 @@ func (c *Config) cacheFromFile() (data *cacheData, err error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.Open(path)
+	// path is built from CachePath() (fixed config dir under user home), not external input.
+	f, err := os.Open(path) //nolint:gosec // G304: path is from fixed config dir, not user-controlled
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -171,6 +176,14 @@ func (c *Config) cacheFromFile() (data *cacheData, err error) {
 		return nil, err
 	}
 	return data, nil
+}
+
+// toInt32 narrows an int to int32, returning an error if it would overflow.
+func toInt32(n int) (int32, error) {
+	if n < math.MinInt32 || n > math.MaxInt32 {
+		return 0, fmt.Errorf("value %d out of int32 range", n)
+	}
+	return int32(n), nil
 }
 
 // detectMIME returns the MIME type of data, falling back to the file extension.
@@ -194,7 +207,8 @@ func LoadImageUploads(paths []string) ([]*proto.ImageUpload, error) {
 	}
 	out := make([]*proto.ImageUpload, 0, len(paths))
 	for _, p := range paths {
-		data, err := os.ReadFile(p)
+		// Paths come from CLI flags supplied by the user; reading them is the intent.
+		data, err := os.ReadFile(p) //nolint:gosec // G304: user-supplied CLI input
 		if err != nil {
 			return nil, fmt.Errorf("read image %s: %w", p, err)
 		}
@@ -214,7 +228,8 @@ func LoadAudioUploads(paths []string) ([]*proto.AudioUpload, error) {
 	}
 	out := make([]*proto.AudioUpload, 0, len(paths))
 	for _, p := range paths {
-		data, err := os.ReadFile(p)
+		// Paths come from CLI flags supplied by the user; reading them is the intent.
+		data, err := os.ReadFile(p) //nolint:gosec // G304: user-supplied CLI input
 		if err != nil {
 			return nil, fmt.Errorf("read audio %s: %w", p, err)
 		}
@@ -291,9 +306,13 @@ func (c *Config) ListPosts(ctx context.Context, count int) ([]*Post, error) {
 	if err != nil {
 		return nil, err
 	}
+	limit, err := toInt32(count)
+	if err != nil {
+		return nil, fmt.Errorf("count: %w", err)
+	}
 	resp, err := g.notesClient.ListNotes(ctx, &proto.ListNotesRequest{
 		UserId: userID,
-		Limit:  int32(count),
+		Limit:  limit,
 	})
 	if err != nil {
 		return nil, err
@@ -311,10 +330,14 @@ func (c *Config) SearchPosts(ctx context.Context, query string, maxResults int) 
 	if err != nil {
 		return nil, err
 	}
+	limit, err := toInt32(maxResults)
+	if err != nil {
+		return nil, fmt.Errorf("maxResults: %w", err)
+	}
 	resp, err := g.notesClient.ListNotes(ctx, &proto.ListNotesRequest{
 		UserId: userID,
 		Search: query,
-		Limit:  int32(maxResults),
+		Limit:  limit,
 	})
 	if err != nil {
 		return nil, err
@@ -332,9 +355,13 @@ func (c *Config) GetRandomPosts(ctx context.Context, count int) ([]*Post, error)
 	if err != nil {
 		return nil, err
 	}
+	c32, err := toInt32(count)
+	if err != nil {
+		return nil, fmt.Errorf("count: %w", err)
+	}
 	resp, err := g.notesClient.GetRandomNotes(ctx, &proto.GetRandomNotesRequest{
 		UserId: userID,
-		Count:  int32(count),
+		Count:  c32,
 	})
 	if err != nil {
 		return nil, err

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,7 +19,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Config{ApiKey: tt.apiKey}
+			c := &Config{APIKey: tt.apiKey}
 			err := c.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
@@ -103,7 +103,7 @@ func TestLoadImageUploads(t *testing.T) {
 		path := filepath.Join(dir, "test.png")
 		// PNG magic bytes
 		data := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
-		if err := os.WriteFile(path, data, 0644); err != nil {
+		if err := os.WriteFile(path, data, 0600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -127,7 +127,7 @@ func TestLoadImageUploads(t *testing.T) {
 		paths := make([]string, 3)
 		for i := range paths {
 			p := filepath.Join(dir, filepath.Base(t.Name())+string(rune('a'+i))+".jpg")
-			if err := os.WriteFile(p, []byte{0xFF, 0xD8, 0xFF}, 0644); err != nil {
+			if err := os.WriteFile(p, []byte{0xFF, 0xD8, 0xFF}, 0600); err != nil {
 				t.Fatal(err)
 			}
 			paths[i] = p
@@ -164,7 +164,7 @@ func TestLoadAudioUploads(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "test.wav")
-		if err := os.WriteFile(path, []byte("fake audio data"), 0644); err != nil {
+		if err := os.WriteFile(path, []byte("fake audio data"), 0600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -191,7 +191,7 @@ func TestLoadAudioUploads(t *testing.T) {
 func TestCacheRoundTrip(t *testing.T) {
 	setTestHome(t)
 
-	cfg := &Config{ApiKey: "test"}
+	cfg := &Config{APIKey: "test"}
 	dur := 5 * time.Minute
 
 	if err := cfg.cacheToFile(dur); err != nil {
@@ -216,7 +216,7 @@ func TestCacheRoundTrip(t *testing.T) {
 func TestCacheOverwrite(t *testing.T) {
 	setTestHome(t)
 
-	cfg := &Config{ApiKey: "test"}
+	cfg := &Config{APIKey: "test"}
 
 	if err := cfg.cacheToFile(1 * time.Minute); err != nil {
 		t.Fatal(err)
@@ -237,7 +237,7 @@ func TestCacheOverwrite(t *testing.T) {
 func TestCacheFromFileMissing(t *testing.T) {
 	setTestHome(t)
 
-	cfg := &Config{ApiKey: "test"}
+	cfg := &Config{APIKey: "test"}
 	data, err := cfg.cacheFromFile()
 	if err != nil {
 		t.Errorf("expected no error for missing cache file, got: %v", err)

--- a/client/config.go
+++ b/client/config.go
@@ -9,7 +9,7 @@ import (
 
 const defaultGRPCTarget = "grpc.etu.timeclimbers.com:443"
 
-// configFile represents the persisted config file format.
+// ConfigFile represents the persisted config file format.
 type ConfigFile struct {
 	APIKey     string `json:"api_key"`
 	GRPCTarget string `json:"grpc_target"`
@@ -55,7 +55,8 @@ func loadConfigFromFile() (*ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(path)
+	// path is from ConfigPath() (fixed config dir under user home), not external input.
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is from fixed config dir, not user-controlled
 	if err != nil {
 		if os.IsNotExist(err) {
 			return SaveConfig("", "")
@@ -80,7 +81,8 @@ func SaveConfig(apiKey, grpcTarget string) (*ConfigFile, error) {
 		return nil, err
 	}
 	cf := &ConfigFile{APIKey: apiKey, GRPCTarget: grpcTarget}
-	data, err := json.Marshal(cf)
+	// Persisting the API key to the user's local config is intentional.
+	data, err := json.Marshal(cf) //nolint:gosec // G117: api_key persistence is the purpose of this file
 	if err != nil {
 		return nil, err
 	}

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -128,8 +128,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("ETU_API_KEY", "env-key")
 
 	cfg := LoadConfig()
-	if cfg.ApiKey != "env-key" {
-		t.Errorf("ApiKey = %q, want %q", cfg.ApiKey, "env-key")
+	if cfg.APIKey != "env-key" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "env-key")
 	}
 	// GRPCTarget defaults from the config file (SaveConfig sets it),
 	// so ETU_GRPC_TARGET env only applies when the file has an empty target.
@@ -143,8 +143,8 @@ func TestLoadConfigTrimsWhitespace(t *testing.T) {
 	t.Setenv("ETU_API_KEY", "  my-key\n")
 
 	cfg := LoadConfig()
-	if cfg.ApiKey != "my-key" {
-		t.Errorf("ApiKey = %q, want %q", cfg.ApiKey, "my-key")
+	if cfg.APIKey != "my-key" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "my-key")
 	}
 }
 
@@ -162,8 +162,8 @@ func TestLoadConfigFileOverridesDefault(t *testing.T) {
 	t.Setenv("ETU_GRPC_TARGET", "")
 
 	cfg := LoadConfig()
-	if cfg.ApiKey != "file-key" {
-		t.Errorf("ApiKey = %q, want %q", cfg.ApiKey, "file-key")
+	if cfg.APIKey != "file-key" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "file-key")
 	}
 	if cfg.GRPCTarget != "file-target:443" {
 		t.Errorf("GRPCTarget = %q, want %q", cfg.GRPCTarget, "file-target:443")

--- a/client/grpc.go
+++ b/client/grpc.go
@@ -75,7 +75,7 @@ type grpcClients struct {
 }
 
 func (c *Config) getGRPCClients() (*grpcClients, error) {
-	if c.ApiKey == "" {
+	if c.APIKey == "" {
 		return nil, fmt.Errorf("API key not set")
 	}
 	// Lazy-init is done in ensureGRPCConn; we need a shared struct. Store on Config.
@@ -86,7 +86,7 @@ func (c *Config) getGRPCClients() (*grpcClients, error) {
 		creds := credentials.NewTLS(&tls.Config{})
 		opts := []grpc.DialOption{
 			grpc.WithTransportCredentials(creds),
-			grpc.WithPerRPCCredentials(apiKeyCreds{apiKey: c.ApiKey}),
+			grpc.WithPerRPCCredentials(apiKeyCreds{apiKey: c.APIKey}),
 		}
 		c.grpc.conn, c.grpc.connErr = grpc.NewClient(c.GRPCTarget, opts...)
 		if c.grpc.connErr != nil {
@@ -109,7 +109,7 @@ func (c *Config) ensureUserID(ctx context.Context) (string, error) {
 	}
 	g.userIDOnce.Do(func() {
 		resp, err := g.apiKeysClient.VerifyApiKey(ctx, &proto.VerifyApiKeyRequest{
-			RawKey: c.ApiKey,
+			RawKey: c.APIKey,
 		})
 		if err != nil {
 			g.userIDErr = err

--- a/list.go
+++ b/list.go
@@ -1,3 +1,4 @@
+// Package main implements the etu CLI: a personal command-line journal.
 package main
 
 import (
@@ -205,7 +206,8 @@ func (m postListModel) View() string {
 
 	var s strings.Builder
 
-	if m.loading {
+	switch {
+	case m.loading:
 		var loadingText string
 		if m.query != "" {
 			loadingText = fmt.Sprintf("%s Searching...", m.spinner.View())
@@ -215,13 +217,13 @@ func (m postListModel) View() string {
 		s.WriteString("\n  ")
 		s.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("170")).Render(loadingText))
 		s.WriteString("\n")
-	} else if m.loadErr != nil {
+	case m.loadErr != nil:
 		s.WriteString("\n  ")
 		s.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("Error: " + m.loadErr.Error()))
 		s.WriteString("\n")
-	} else if len(m.posts) > 0 {
+	case len(m.posts) > 0:
 		s.WriteString(m.list.View())
-	} else {
+	default:
 		s.WriteString("\n  No entries found.\n")
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var (
 		Use:   "etu",
 		Short: "Etu. A personal command line journal.",
 		Args:  cobra.NoArgs,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			// Skip API key validation for these commands (they don't need the backend)
 			curr := cmd
 			for curr != nil {
@@ -45,7 +45,7 @@ var (
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}
@@ -106,7 +106,7 @@ var (
 	}
 )
 
-func createPost(cmd *cobra.Command, args []string) error {
+func createPost(cmd *cobra.Command, _ []string) error {
 	// Check if stdin has data (piped input)
 	stat, err := os.Stdin.Stat()
 	if err != nil {
@@ -193,18 +193,19 @@ func createPost(cmd *cobra.Command, args []string) error {
 	return saveErr
 }
 
-func timeSinceLastPost(cmd *cobra.Command, args []string) error {
+func timeSinceLastPost(cmd *cobra.Command, _ []string) error {
 	dur, err := cfg.TimeSinceLastPost(cmd.Context())
 	if err != nil {
+		// Intentional: print a "???" sentinel so shell prompts don't break.
 		fmt.Print("???")
-		return nil
+		return nil //nolint:nilerr // sentinel output is the desired behavior here
 	}
 
 	fmt.Print(formatDuration(dur))
 	return nil
 }
 
-func deletePost(cmd *cobra.Command, args []string) error {
+func deletePost(cmd *cobra.Command, _ []string) error {
 	// Show list of posts to select from
 	model := newPostListModel(cfg, 25, "Select entry to delete", true)
 	p := tea.NewProgram(model, tea.WithAltScreen())
@@ -255,7 +256,7 @@ func deletePost(cmd *cobra.Command, args []string) error {
 	return deleteErr
 }
 
-func mostRecentPost(cmd *cobra.Command, args []string) error {
+func mostRecentPost(cmd *cobra.Command, _ []string) error {
 	posts, err := cfg.ListPosts(cmd.Context(), 1)
 	if err != nil {
 		return err
@@ -276,7 +277,7 @@ func mostRecentPost(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func listPosts(cmd *cobra.Command, args []string) error {
+func listPosts(cmd *cobra.Command, _ []string) error {
 	model := newPostListModel(cfg, 25, "Interstitial Notes", true)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	finalModel, err := p.Run()
@@ -291,7 +292,7 @@ func listPosts(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func randomPost(cmd *cobra.Command, args []string) error {
+func randomPost(cmd *cobra.Command, _ []string) error {
 	posts, err := cfg.GetRandomPosts(cmd.Context(), 1)
 	if err != nil {
 		return err
@@ -385,7 +386,7 @@ func init() {
 func main() {
 	// Load config (file + ETU_API_KEY / ETU_GRPC_TARGET env) and persist so we don't have to mess with env later.
 	cfg = client.LoadConfig()
-	if _, err := client.SaveConfig(cfg.ApiKey, cfg.GRPCTarget); err != nil {
+	if _, err := client.SaveConfig(cfg.APIKey, cfg.GRPCTarget); err != nil {
 		log.Fatal(err)
 	}
 	if err := rootCmd.Execute(); err != nil {

--- a/show.go
+++ b/show.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh/spinner"
@@ -22,7 +24,7 @@ var showCmd = &cobra.Command{
 	RunE:  showPost,
 }
 
-func showPost(cmd *cobra.Command, args []string) error {
+func showPost(cmd *cobra.Command, _ []string) error {
 	// Show list of posts to select from
 	model := newPostListModel(cfg, 25, "Select entry to view", true)
 	p := tea.NewProgram(model, tea.WithAltScreen())
@@ -82,7 +84,7 @@ func displayPost(cmd *cobra.Command, post *client.Post) error {
 				fmt.Println(labelStyle.Render("     Text: ") + truncate(img.GetExtractedText(), 80))
 			}
 			// Try to display image inline if terminal supports it
-			displayImageInline(img.GetUrl())
+			displayImageInline(cmd.Context(), img.GetUrl())
 		}
 	}
 
@@ -102,29 +104,36 @@ func displayPost(cmd *cobra.Command, post *client.Post) error {
 	return nil
 }
 
-func truncate(s string, max int) string {
+func truncate(s string, maxLen int) string {
 	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) <= max {
+	if len(s) <= maxLen {
 		return s
 	}
-	return s[:max-3] + "..."
+	return s[:maxLen-3] + "..."
 }
 
-// displayImageInline attempts to display an image inline using iTerm2's protocol
-func displayImageInline(url string) {
+// displayImageInline attempts to display an image inline using iTerm2's protocol.
+func displayImageInline(ctx context.Context, url string) {
 	// Check if we're in iTerm2
 	if os.Getenv("TERM_PROGRAM") != "iTerm.app" {
 		return
 	}
 
-	// Fetch the image
-	resp, err := http.Get(url)
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	// URL comes from our trusted backend (signed media URL); fire-and-forget terminal eye-candy.
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, http.NoBody) //nolint:gosec // G107: trusted backend-issued URL
+	if err != nil {
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return
 	}
 	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", err)
+		if cerr := resp.Body.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "failed to close response body: %v\n", cerr)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the findings so the lint check passes.

## Changes
- **revive**: added package comments to `client` and `main`; renamed unused `args` cobra params to `_`; fixed `ConfigFile` doc comment; renamed `truncate`'s `max` parameter to `maxLen` (built-in shadow); renamed `Config.ApiKey` to `APIKey` (var-naming), updating all callers and tests.
- **gosec**:
  - G304 (`os.Create`/`os.Open`/`os.ReadFile`): added `//nolint:gosec` with reasons (paths are fixed config-dir or user-supplied CLI flags).
  - G115 (int->int32): added `toInt32` helper with bounds check; replaced unchecked casts in `ListPosts`/`SearchPosts`/`GetRandomPosts`.
  - G117 (`json.Marshal` of struct with api_key): nolint, persisting the key is the file's purpose.
  - G306 (test `0644`): switched test `os.WriteFile` perms to `0600`.
  - G107 (variable HTTP URL in `displayImageInline`): nolint with reason; also rewrote to use `http.NewRequestWithContext` with a 10s timeout, threading `cmd.Context()` through.
- **nilerr** (`timeSinceLastPost`): nolint with reason - sentinel `???` output is intentional so shell prompts don't break.
- **gocritic** (`ifElseChain` in `list.go View()`): rewrote as `switch`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` - 0 issues
- `go build ./...` - passes
- `go test ./...` - passes

Generated with [Claude Code](https://claude.com/claude-code)