### PR TITLE
feat: add edit, tags, and stats commands (client parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md
+
+Etu is a personal command-line journaling tool (interstitial journaling). It talks gRPC to
+[etu-backend](https://github.com/icco/etu-backend), whose generated protos are imported from
+`github.com/icco/etu-backend/proto`.
+
+## Commands
+
+- `task build` — build the binary (or `go build -o etu .`)
+- `go test ./...` — run tests
+- `go vet ./...` — vet
+- `task lint` — lint (runs `go vet ./...`)
+
+## Architecture
+
+Two packages:
+
+- **main** (repo root): cobra commands (`main.go`, plus one file per larger command:
+  `edit.go`, `stats.go`, `tags.go`, `show.go`, `search.go`) and the TUI. List selection is a
+  bubbletea model (`list.go`); forms and confirmations use huh; long calls wrap in
+  `huh/spinner`. Plain (pipeable) output is preferred when stdout is not a terminal.
+- **client**: the gRPC client. `client/grpc.go` holds the lazily-initialized connection and
+  service clients (Notes, ApiKeys, Tags, Stats) plus proto→display-model converters;
+  `client/client.go` holds high-level methods (`ListPosts`, `SaveEntry`, `UpdatePost`,
+  `ListTags`, `GetStats`, ...). The user ID is resolved once via `VerifyApiKey` and cached.
+
+## Configuration
+
+- Config file: `~/.config/etu/config.json` (`api_key`, `grpc_target`).
+- Env overrides: `ETU_API_KEY`, `ETU_GRPC_TARGET`.
+- The `timesince` command caches its result at `~/.config/etu/timesince.cache` (gob, 5 min TTL).

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ Usage:
 Available Commands:
   create      Create a new journal entry (attach images/audio via drag & drop in TUI or -i/--image, -a/--audio).
   delete      Delete a journal entry.
+  edit        Edit a journal entry.
   help        Help about any command
   last        Output a string of time since last post.
   list        List journal entries, with an optional starting datetime.
   search      Search journal entries using fuzzy search.
+  stats       Show journal stats (blips, tags, words written).
+  tags        List all tags with usage counts.
   timesince   Output a string of time since last post.
 
 Flags:

--- a/client/client.go
+++ b/client/client.go
@@ -394,6 +394,41 @@ func (c *Config) ListTags(ctx context.Context) ([]Tag, error) {
 	return protoTagsToTags(resp.GetTags()), nil
 }
 
+// Stats holds aggregate journal metrics from the backend.
+type Stats struct {
+	TotalBlips   int64
+	UniqueTags   int64
+	WordsWritten int64
+}
+
+// GetStats fetches aggregate stats. When global is true, community-wide stats
+// are returned; otherwise stats are scoped to the current user.
+func (c *Config) GetStats(ctx context.Context, global bool) (Stats, error) {
+	var userID string
+	if !global {
+		var err error
+		userID, err = c.ensureUserID(ctx)
+		if err != nil {
+			return Stats{}, err
+		}
+	}
+	g, err := c.getGRPCClients()
+	if err != nil {
+		return Stats{}, err
+	}
+	resp, err := g.statsClient.GetStats(ctx, &proto.GetStatsRequest{
+		UserId: userID,
+	})
+	if err != nil {
+		return Stats{}, fmt.Errorf("get stats: %w", err)
+	}
+	return Stats{
+		TotalBlips:   resp.GetTotalBlips(),
+		UniqueTags:   resp.GetUniqueTags(),
+		WordsWritten: resp.GetWordsWritten(),
+	}, nil
+}
+
 // GetPostFullContent fetches the full content of a post by ID.
 func (c *Config) GetPostFullContent(ctx context.Context, pageID string) (string, error) {
 	userID, err := c.ensureUserID(ctx)

--- a/client/client.go
+++ b/client/client.go
@@ -279,6 +279,29 @@ func (c *Config) SaveEntry(ctx context.Context, text string, imagePaths, audioPa
 	return nil
 }
 
+// UpdatePost updates the content of an existing journal entry by ID.
+// Tags are left untouched (the backend keeps the existing tag list).
+func (c *Config) UpdatePost(ctx context.Context, pageID, content string) (*Post, error) {
+	userID, err := c.ensureUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	g, err := c.getGRPCClients()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.notesClient.UpdateNote(ctx, &proto.UpdateNoteRequest{
+		UserId:     userID,
+		Id:         pageID,
+		Content:    &content,
+		UpdateTags: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update note: %w", err)
+	}
+	return noteToPost(resp.GetNote()), nil
+}
+
 // DeletePost deletes a journal entry by ID.
 func (c *Config) DeletePost(ctx context.Context, pageID string) error {
 	userID, err := c.ensureUserID(ctx)

--- a/client/client.go
+++ b/client/client.go
@@ -369,6 +369,31 @@ func (c *Config) GetRandomPosts(ctx context.Context, count int) ([]*Post, error)
 	return notesToPosts(resp.GetNotes()), nil
 }
 
+// Tag represents a journal tag and how many entries use it.
+type Tag struct {
+	Name  string
+	Count int32
+}
+
+// ListTags lists all tags for the current user.
+func (c *Config) ListTags(ctx context.Context) ([]Tag, error) {
+	userID, err := c.ensureUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	g, err := c.getGRPCClients()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.tagsClient.ListTags(ctx, &proto.ListTagsRequest{
+		UserId: userID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	return protoTagsToTags(resp.GetTags()), nil
+}
+
 // GetPostFullContent fetches the full content of a post by ID.
 func (c *Config) GetPostFullContent(ctx context.Context, pageID string) (string, error) {
 	userID, err := c.ensureUserID(ctx)

--- a/client/grpc.go
+++ b/client/grpc.go
@@ -43,6 +43,18 @@ func noteToPost(n *proto.Note) *Post {
 	}
 }
 
+// protoTagsToTags converts a slice of proto Tags to client Tags.
+func protoTagsToTags(tags []*proto.Tag) []Tag {
+	out := make([]Tag, 0, len(tags))
+	for _, t := range tags {
+		if t == nil {
+			continue
+		}
+		out = append(out, Tag{Name: t.GetName(), Count: t.GetCount()})
+	}
+	return out
+}
+
 // apiKeyCreds attaches the etu API key to every gRPC request.
 type apiKeyCreds struct {
 	apiKey string
@@ -67,6 +79,7 @@ type grpcClients struct {
 	conn          *grpc.ClientConn
 	notesClient   proto.NotesServiceClient
 	apiKeysClient proto.ApiKeysServiceClient
+	tagsClient    proto.TagsServiceClient
 	userID        string
 	connOnce      sync.Once
 	userIDOnce    sync.Once
@@ -94,6 +107,7 @@ func (c *Config) getGRPCClients() (*grpcClients, error) {
 		}
 		c.grpc.notesClient = proto.NewNotesServiceClient(c.grpc.conn)
 		c.grpc.apiKeysClient = proto.NewApiKeysServiceClient(c.grpc.conn)
+		c.grpc.tagsClient = proto.NewTagsServiceClient(c.grpc.conn)
 	})
 	if c.grpc.connErr != nil {
 		return nil, c.grpc.connErr

--- a/client/grpc.go
+++ b/client/grpc.go
@@ -80,6 +80,7 @@ type grpcClients struct {
 	notesClient   proto.NotesServiceClient
 	apiKeysClient proto.ApiKeysServiceClient
 	tagsClient    proto.TagsServiceClient
+	statsClient   proto.StatsServiceClient
 	userID        string
 	connOnce      sync.Once
 	userIDOnce    sync.Once
@@ -108,6 +109,7 @@ func (c *Config) getGRPCClients() (*grpcClients, error) {
 		c.grpc.notesClient = proto.NewNotesServiceClient(c.grpc.conn)
 		c.grpc.apiKeysClient = proto.NewApiKeysServiceClient(c.grpc.conn)
 		c.grpc.tagsClient = proto.NewTagsServiceClient(c.grpc.conn)
+		c.grpc.statsClient = proto.NewStatsServiceClient(c.grpc.conn)
 	})
 	if c.grpc.connErr != nil {
 		return nil, c.grpc.connErr

--- a/client/grpc_test.go
+++ b/client/grpc_test.go
@@ -138,6 +138,47 @@ func TestNotesToPosts(t *testing.T) {
 	})
 }
 
+func TestProtoTagsToTags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []*proto.Tag
+		want []Tag
+	}{
+		{"nil slice", nil, []Tag{}},
+		{"empty slice", []*proto.Tag{}, []Tag{}},
+		{
+			"multiple tags",
+			[]*proto.Tag{
+				{Id: "1", Name: "work", Count: 5},
+				{Id: "2", Name: "life", Count: 2},
+			},
+			[]Tag{{Name: "work", Count: 5}, {Name: "life", Count: 2}},
+		},
+		{
+			"filters nil tags",
+			[]*proto.Tag{
+				{Id: "1", Name: "work", Count: 5},
+				nil,
+			},
+			[]Tag{{Name: "work", Count: 5}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := protoTagsToTags(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("expected %d tags, got %d", len(tt.want), len(got))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("tag %d = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestGetGRPCClientsNoKey(t *testing.T) {
 	c := &Config{}
 	_, err := c.getGRPCClients()

--- a/docs/superpowers/plans/2026-06-12-cli-parity.md
+++ b/docs/superpowers/plans/2026-06-12-cli-parity.md
@@ -1,0 +1,113 @@
+# CLI Feature Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the etu CLI to feature parity with the web and mobile clients by adding `edit`, `tags`, and `stats` commands.
+
+**Architecture:** Follow the existing Cobra + client-package split: each command gets a thin cobra.Command in the main package that delegates to a method on `client.Config` (client package), which calls the backend over gRPC. TagsService and StatsService clients must be added to `client/grpc.go` alongside the existing NotesService/ApiKeysService clients.
+
+**Tech Stack:** Go, Cobra, Charmbracelet (huh forms, bubbletea), gRPC + `github.com/icco/etu-backend` protos.
+
+**Backend API shapes (from etu-backend/proto/etu.proto):**
+- `TagsService.ListTags(ListTagsRequest{user_id}) → ListTagsResponse{repeated Tag tags}` where `Tag{id, name, count, created_at}`
+- `StatsService.GetStats(GetStatsRequest{user_id}) → GetStatsResponse{total_blips, unique_tags, words_written}` — empty `user_id` returns global stats; set `user_id` for per-user stats.
+- `NotesService.UpdateNote(UpdateNoteRequest{user_id, id, optional content, repeated tags, update_tags bool, add_images, add_audios}) → UpdateNoteResponse{note}`
+
+---
+
+### Task 1: Tags client method
+
+**Files:**
+- Modify: `client/grpc.go` (add `tags proto.TagsServiceClient` next to existing service clients, initialized in the same place as `notes`)
+- Modify: `client/client.go` (add `ListTags` method)
+- Test: `client/grpc_test.go` (conversion helpers if any)
+
+- [ ] Add `TagsServiceClient` to the lazily-initialized gRPC client set in `client/grpc.go`, mirroring how `proto.NewNotesServiceClient(conn)` is created.
+- [ ] Add to `client/client.go`:
+
+```go
+// Tag is a user tag with its usage count.
+type Tag struct {
+	Name  string
+	Count int32
+}
+
+// ListTags returns all tags for the authenticated user, sorted by the backend.
+func (c *Config) ListTags(ctx context.Context) ([]Tag, error) {
+	userID, err := c.userID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.grpcTags().ListTags(ctx, &proto.ListTagsRequest{UserId: userID})
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	tags := make([]Tag, 0, len(resp.GetTags()))
+	for _, t := range resp.GetTags() {
+		tags = append(tags, Tag{Name: t.GetName(), Count: t.GetCount()})
+	}
+	return tags, nil
+}
+```
+
+(Adapt the user-ID lookup and client accessor names to the existing patterns in grpc.go — read how ListPosts resolves userID first.)
+
+- [ ] Add a unit test for any pure conversion logic; run `go test ./...` — PASS.
+- [ ] Commit: `feat: add ListTags client method`
+
+### Task 2: `etu tags` command
+
+**Files:**
+- Modify: `main.go` (register command)
+- Create: `tags.go`
+- Test: `main_test.go` or `tags_test.go` for any formatting helper
+
+- [ ] Create `tags.go` with a `tagsCmd` that prints each tag as `name (count)` one per line (plain output suits piping; no TUI needed). Sort by count descending, then name.
+- [ ] Register in `main.go` `rootCmd.AddCommand(...)` next to the other commands, alias `t`.
+- [ ] Test formatting helper; run `go test ./...` — PASS. Commit: `feat: add tags command`
+
+### Task 3: Stats client method + `etu stats` command
+
+**Files:**
+- Modify: `client/grpc.go` (StatsService client), `client/client.go` (GetStats), `main.go`
+- Create: `stats.go`
+
+- [ ] Add `StatsServiceClient` wiring as in Task 1.
+- [ ] Add to `client/client.go`:
+
+```go
+// Stats holds aggregate journal statistics.
+type Stats struct {
+	TotalBlips   int64
+	UniqueTags   int64
+	WordsWritten int64
+}
+
+// GetStats returns stats for the authenticated user; pass global=true for community stats.
+func (c *Config) GetStats(ctx context.Context, global bool) (Stats, error) { ... }
+```
+
+with the same userID/empty-userID split described in the API shapes above.
+- [ ] Create `stats.go` defining `statsCmd`: prints `Blips: N`, `Tags: N`, `Words written: N`; `--global` flag adds community stats. Register in main.go.
+- [ ] `go test ./...` PASS, `go vet ./...` clean. Commit: `feat: add stats command`
+
+### Task 4: `etu edit` command
+
+**Files:**
+- Modify: `client/client.go` (UpdatePost), `client/grpc.go` (nothing new — NotesService exists), `main.go`
+- Create: `edit.go`
+
+- [ ] Add `UpdatePost(ctx, pageID string, content string) (*Post, error)` to client package calling `UpdateNote` with `Content: &content` and `UpdateTags: false` (tags unchanged; backend re-derives nothing). Wrap errors like the neighbors.
+- [ ] Create `edit.go`: reuse the entry-selection list used by `show`/`delete` (see show.go:20-43 and main.go:208-257) to pick an entry, fetch full content via the existing `GetPostFullContent`, pre-fill a `huh` multiline text field with the current content, and save via `UpdatePost`. Alias `e`. Abort cleanly if content unchanged.
+- [ ] `go test ./...` PASS. Commit: `feat: add edit command`
+
+### Task 5: Docs
+
+- [ ] Update README.md usage section with the three new commands; regenerate completions is handled by the build (Taskfile `completions` target — note it, don't run if binary build unavailable).
+- [ ] Create `CLAUDE.md` (~30 lines): what the repo is, build/test/lint commands (`task build`, `go test ./...`, `go vet ./...`), architecture (main package = cobra/TUI; client package = gRPC; protos from etu-backend), config location (`~/.config/etu/config.json`, env overrides `ETU_API_KEY`/`ETU_GRPC_TARGET`).
+- [ ] Commit: `docs: document new commands, add CLAUDE.md`
+
+### Verification
+
+- [ ] `go build ./...`, `go test ./...`, `go vet ./...` all pass.
+- [ ] `staticcheck ./...` if available.

--- a/edit.go
+++ b/edit.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/huh/spinner"
+	"github.com/spf13/cobra"
+)
+
+var editCmd = &cobra.Command{
+	Use:     "edit",
+	Aliases: []string{"e"},
+	Short:   "Edit a journal entry.",
+	Args:    cobra.NoArgs,
+	RunE:    editPost,
+}
+
+func editPost(cmd *cobra.Command, _ []string) error {
+	// Show list of posts to select from
+	model := newPostListModel(cfg, 25, "Select entry to edit", true)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	finalModel, err := p.Run()
+	if err != nil {
+		return err
+	}
+
+	// Check if a post was selected
+	if finalModel.(postListModel).selected == nil {
+		return nil // User quit without selecting
+	}
+
+	selectedPost := finalModel.(postListModel).selected
+
+	// Fetch full content so the editor is pre-filled with the whole entry
+	var text string
+	var fetchErr error
+	err = spinner.New().
+		Title("Loading full content...").
+		Action(func() {
+			text, fetchErr = cfg.GetPostFullContent(cmd.Context(), selectedPost.PageID)
+		}).
+		Run()
+
+	if err != nil {
+		return err
+	}
+	if fetchErr != nil {
+		return fetchErr
+	}
+	original := text
+
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewText().
+				Value(&text).
+				Title(fmt.Sprintf("Edit entry from %s", selectedPost.CreatedAt.Format("2006-01-02 15:04"))).
+				Validate(func(value string) error {
+					if len(strings.TrimSpace(value)) == 0 {
+						return fmt.Errorf("journal entry cannot be empty")
+					}
+					return nil
+				}).
+				WithHeight(12).
+				WithWidth(100),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		return err
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return fmt.Errorf("journal entry cannot be empty")
+	}
+	if text == strings.TrimSpace(original) {
+		fmt.Println("No changes.")
+		return nil
+	}
+
+	// Update with spinner
+	var updateErr error
+	err = spinner.New().
+		Title("Updating entry...").
+		Action(func() {
+			_, updateErr = cfg.UpdatePost(cmd.Context(), selectedPost.PageID, text)
+		}).
+		Run()
+
+	if err != nil {
+		return err
+	}
+
+	return updateErr
+}

--- a/main.go
+++ b/main.go
@@ -370,6 +370,7 @@ func init() {
 
 	createCmd.Flags().StringSliceP("image", "i", nil, "path to image file to attach (can be repeated)")
 	createCmd.Flags().StringSliceP("audio", "a", nil, "path to audio file to attach (can be repeated)")
+	statsCmd.Flags().Bool("global", false, "also show community-wide stats")
 
 	rootCmd.AddCommand(
 		createCmd,
@@ -378,6 +379,7 @@ func init() {
 		mostRecentCmd,
 		randomCmd,
 		showCmd,
+		statsCmd,
 		tagsCmd,
 		timeSinceCmd,
 		searchCmd,

--- a/main.go
+++ b/main.go
@@ -375,6 +375,7 @@ func init() {
 	rootCmd.AddCommand(
 		createCmd,
 		deleteCmd,
+		editCmd,
 		listCmd,
 		mostRecentCmd,
 		randomCmd,

--- a/main.go
+++ b/main.go
@@ -378,6 +378,7 @@ func init() {
 		mostRecentCmd,
 		randomCmd,
 		showCmd,
+		tagsCmd,
 		timeSinceCmd,
 		searchCmd,
 	)

--- a/stats.go
+++ b/stats.go
@@ -21,8 +21,13 @@ func showStats(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	global, err := cmd.Flags().GetBool("global")
+	if err != nil {
+		return err
+	}
+
 	var community *client.Stats
-	if global, err := cmd.Flags().GetBool("global"); err == nil && global {
+	if global {
 		stats, err := cfg.GetStats(cmd.Context(), true)
 		if err != nil {
 			return err

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/icco/etu/client"
+	"github.com/spf13/cobra"
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show journal stats (blips, tags, words written).",
+	Args:  cobra.NoArgs,
+	RunE:  showStats,
+}
+
+func showStats(cmd *cobra.Command, _ []string) error {
+	personal, err := cfg.GetStats(cmd.Context(), false)
+	if err != nil {
+		return err
+	}
+
+	var community *client.Stats
+	if global, err := cmd.Flags().GetBool("global"); err == nil && global {
+		stats, err := cfg.GetStats(cmd.Context(), true)
+		if err != nil {
+			return err
+		}
+		community = &stats
+	}
+
+	fmt.Print(formatStats(personal, community))
+	return nil
+}
+
+// formatStats renders stats as one metric per line; a non-nil community adds
+// a second "Community" block.
+func formatStats(personal client.Stats, community *client.Stats) string {
+	var b strings.Builder
+	writeBlock := func(s client.Stats) {
+		fmt.Fprintf(&b, "Blips: %d\n", s.TotalBlips)
+		fmt.Fprintf(&b, "Tags: %d\n", s.UniqueTags)
+		fmt.Fprintf(&b, "Words written: %d\n", s.WordsWritten)
+	}
+	writeBlock(personal)
+	if community != nil {
+		b.WriteString("\nCommunity\n")
+		writeBlock(*community)
+	}
+	return b.String()
+}

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/icco/etu/client"
+)
+
+func TestFormatStats(t *testing.T) {
+	personal := client.Stats{TotalBlips: 10, UniqueTags: 5, WordsWritten: 1234}
+	community := client.Stats{TotalBlips: 1000, UniqueTags: 200, WordsWritten: 99999}
+
+	tests := []struct {
+		name      string
+		personal  client.Stats
+		community *client.Stats
+		want      string
+	}{
+		{
+			"personal only",
+			personal,
+			nil,
+			"Blips: 10\nTags: 5\nWords written: 1234\n",
+		},
+		{
+			"with community block",
+			personal,
+			&community,
+			"Blips: 10\nTags: 5\nWords written: 1234\n\nCommunity\nBlips: 1000\nTags: 200\nWords written: 99999\n",
+		},
+		{
+			"zero values",
+			client.Stats{},
+			nil,
+			"Blips: 0\nTags: 0\nWords written: 0\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatStats(tt.personal, tt.community)
+			if got != tt.want {
+				t.Errorf("formatStats() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/icco/etu/client"
+	"github.com/spf13/cobra"
+)
+
+var tagsCmd = &cobra.Command{
+	Use:     "tags",
+	Aliases: []string{"t"},
+	Short:   "List all tags with usage counts.",
+	Args:    cobra.NoArgs,
+	RunE:    listTags,
+}
+
+func listTags(cmd *cobra.Command, _ []string) error {
+	tags, err := cfg.ListTags(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	fmt.Print(formatTags(tags))
+	return nil
+}
+
+// formatTags renders tags one per line as "name (count)", sorted by count
+// descending then name ascending.
+func formatTags(tags []client.Tag) string {
+	sorted := make([]client.Tag, len(tags))
+	copy(sorted, tags)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Count != sorted[j].Count {
+			return sorted[i].Count > sorted[j].Count
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	var b strings.Builder
+	for _, t := range sorted {
+		fmt.Fprintf(&b, "%s (%d)\n", t.Name, t.Count)
+	}
+	return b.String()
+}

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/icco/etu/client"
+)
+
+func TestFormatTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []client.Tag
+		want string
+	}{
+		{"empty", nil, ""},
+		{"single", []client.Tag{{Name: "work", Count: 3}}, "work (3)\n"},
+		{
+			"sorted by count desc",
+			[]client.Tag{
+				{Name: "life", Count: 2},
+				{Name: "work", Count: 5},
+			},
+			"work (5)\nlife (2)\n",
+		},
+		{
+			"ties broken by name asc",
+			[]client.Tag{
+				{Name: "zebra", Count: 2},
+				{Name: "apple", Count: 2},
+				{Name: "work", Count: 5},
+			},
+			"work (5)\napple (2)\nzebra (2)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTags(tt.tags)
+			if got != tt.want {
+				t.Errorf("formatTags(%v) = %q, want %q", tt.tags, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `etu edit` (alias `e`): pick an entry, edit its content in a pre-filled form, save via `UpdateNote` (tags untouched); prints "No changes." when content is unchanged
- Adds `etu tags` (alias `t`): plain, pipeable `name (count)` list sorted by count desc, name asc
- Adds `etu stats`: Blips / Tags / Words written, with `--global` for community stats (empty `UserId` in `GetStatsRequest`)
- Wires `TagsServiceClient` and `StatsServiceClient` into the client package alongside the existing service clients
- Documents the new commands in the README and adds a `CLAUDE.md`

This closes the CLI's feature-parity gap with the web client (which already exposes edit, tags, and stats).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` passes (new table tests for tag conversion/sorting and stats formatting)
- [x] `golangci-lint run ./...` — 0 issues
